### PR TITLE
Check f$conns before use

### DIFF
--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -193,10 +193,13 @@ function check_ssns(c: connection, data: string): bool
 event SsnExposure::stream_data(f: fa_file, data: string)
 	{
 	local c: connection;
-	for ( id in f$conns )
+	if ( f?$conns )
 		{
-		c = f$conns[id];
-		break;
+		for ( id in f$conns )
+			{
+			c = f$conns[id];
+			break;
+			}
 		}
 	if ( c$start_time > network_time()-10secs )
 		check_ssns(c, data);


### PR DESCRIPTION
The fa_file$conns field is optional, so it should be tested before use.